### PR TITLE
Prevent repeated ECC warning dialogs

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -302,10 +302,10 @@ namespace Q4Sender
 
             if (_invalidEccValue != null && !_eccWarningShown)
             {
+                _eccWarningShown = true; // 警告ダイアログが多重に開かないように先にフラグを更新
                 MessageBox.Show(this,
                     $"QR誤り訂正レベルの設定値 '{_invalidEccValue}' は無効です。既定値(Q)を使用します。",
                     "Q4Sender", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _eccWarningShown = true;
             }
 
             try


### PR DESCRIPTION
## Summary
- prevent the invalid ECC warning dialog from opening repeatedly when the timer fires while the first dialog is still displayed
- set the suppression flag before showing the message box so it only appears once per session

## Testing
- not run (WinForms UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d93788f1e4832fae206699e037c22a